### PR TITLE
Update to Bundler version 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     scrub_rb (1.0.1)
     sequel (4.49.0)
     slop (3.6.0)
-    traject (2.3.4)
+    traject (2.3.4-java)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
       hashie (~> 3.1)
@@ -35,6 +35,7 @@ GEM
       marc (~> 1.0)
       marc-fastxmlwriter (~> 1.0)
       slop (>= 3.4.5, < 4.0)
+      traject-marc4j_reader (~> 1.0)
       yell
     traject-marc4j_reader (1.0.2-java)
       marc (~> 1.0)
@@ -52,6 +53,7 @@ GEM
 
 PLATFORMS
   java
+  universal-java-1.8
 
 DEPENDENCIES
   concurrent-ruby (~> 1.0)
@@ -68,4 +70,4 @@ DEPENDENCIES
   traject_umich_format (~> 0.4)
 
 BUNDLED WITH
-   1.16.1
+   2.2.11

--- a/conf/horizon_index.rb
+++ b/conf/horizon_index.rb
@@ -250,16 +250,3 @@ to_field "location_facet" do |record, accumulator|
   # PI wants no 'Unknown' https://wiki.library.jhu.edu/display/HILT/March+4+2014+Agenda
   #accumulator << "Unknown" if accumulator.empty?
 end
-
-# Okay, anything that's been classified as format "Online", we want to index as in
-# EVERY location facet, per request of PIG March 2014.
-all_location_values = (Traject::TranslationMap.new("jh_locations").to_hash.values.flatten + 
-  Traject::TranslationMap.new("jh_collections").to_hash.values.flatten).uniq
-all_location_values.delete_if {|a| a.nil? || a.empty?}
-each_record do |record, context|
-  if (context.output_hash["format"] || []).include? "Online"
-      context.output_hash["location_facet"] ||= []
-      context.output_hash["location_facet"].concat all_location_values
-      context.output_hash["location_facet"].uniq!
-  end
-end


### PR DESCRIPTION
Our chruby role installs bundler automatically, but
it gets the newest version (now 2.x). This needs to be updated
in the lock file so that it will work with bundler v2.x.